### PR TITLE
fix: always use 1 wei minBuyAmount to leverage CoW MEV protection

### DIFF
--- a/src/app/api/polyswap/orders/create/route.ts
+++ b/src/app/api/polyswap/orders/create/route.ts
@@ -113,10 +113,10 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Set defaults for optional fields
-    if (!body.minBuyAmount) {
-      body.minBuyAmount = "1";
-    }
+    // Always use 1 wei as minimum buy amount to leverage CoW's MEV protection
+    // through solver competition. This prevents blocking order execution
+    // while still ensuring users get the best price from competing solvers.
+    body.minBuyAmount = "1";
 
     if (!body.startDate) {
       body.startDate = "now";


### PR DESCRIPTION
- Remove auto-fill of minBuyAmount from quote in CreateOrderView
- Force minBuyAmount to 1 wei in order submission
- Update backend to always set minBuyAmount to 1 wei

This allows CoW Protocol's solver competition to provide MEV protection instead of blocking order execution with high slippage protection values.